### PR TITLE
Few minor bug fixes.

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,7 +7,7 @@ With [[https://github.com/dimitri/el-get][el-get]] you can install helm-clojure 
          :type github
          :pkgname "prepor/helm-clojure"
          :features helm-clojure
-         :depends (s dash cider helm yasnippet))
+         :depends (s dash cider helm yasnippet smartparens))
 #+END_SRC
 ** References insertion
 helm-clojure is smart enough to insert references with regard of the current namespace.

--- a/helm-clojure.el
+++ b/helm-clojure.el
@@ -33,6 +33,9 @@
 (require 's)
 (require 'dash)
 
+(require 'yasnippet)
+(require 'smartparens)
+
 (defun helm--get-string-from-file (filePath)
   "Return filePath's file content."
   (with-temp-buffer
@@ -92,7 +95,7 @@
   (concat (plist-get c :ns) "/" (plist-get c :symbol)))
 
 (defun helm-clojure-jump (c)
-  (cider-jump-to-var (helm-clojure-candidate-to-sym c))
+  (cider-jump-to-var 0 (helm-clojure-candidate-to-sym c))
   (helm-highlight-current-line))
 
 (defun helm-clojure-doc (c)


### PR DESCRIPTION
Added to require calls for yasnippet and smartparens. Fixed a bug with
cider-jump-to-var taking another arg. Added smartparens to el-get recipe.
